### PR TITLE
[Elixir] Fixes Typespec for multiple return definitions

### DIFF
--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -83,7 +83,7 @@ defmodule OpenapiPetstore.Api.Pet do
   {:ok, [%Pet{}, ...]} on success
   {:error, info} on failure
   """
-  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_status(connection, status, _opts \\ []) do
     %{}
     |> method(:get)
@@ -111,7 +111,7 @@ defmodule OpenapiPetstore.Api.Pet do
   {:ok, [%Pet{}, ...]} on success
   {:error, info} on failure
   """
-  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_tags(connection, tags, _opts \\ []) do
     %{}
     |> method(:get)
@@ -139,7 +139,7 @@ defmodule OpenapiPetstore.Api.Pet do
   {:ok, %OpenapiPetstore.Model.Pet{}} on success
   {:error, info} on failure
   """
-  @spec get_pet_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, OpenapiPetstore.Model.Pet.t} | {:error, Tesla.Env.t}
+  @spec get_pet_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Pet.t} | {:error, Tesla.Env.t}
   def get_pet_by_id(connection, pet_id, _opts \\ []) do
     %{}
     |> method(:get)

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/store.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/store.ex
@@ -77,7 +77,7 @@ defmodule OpenapiPetstore.Api.Store do
   {:ok, %OpenapiPetstore.Model.Order{}} on success
   {:error, info} on failure
   """
-  @spec get_order_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
+  @spec get_order_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
   def get_order_by_id(connection, order_id, _opts \\ []) do
     %{}
     |> method(:get)
@@ -104,7 +104,7 @@ defmodule OpenapiPetstore.Api.Store do
   {:ok, %OpenapiPetstore.Model.Order{}} on success
   {:error, info} on failure
   """
-  @spec place_order(Tesla.Env.client, OpenapiPetstore.Model.Order.t, keyword()) :: {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
+  @spec place_order(Tesla.Env.client, OpenapiPetstore.Model.Order.t, keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
   def place_order(connection, body, _opts \\ []) do
     %{}
     |> method(:post)

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
@@ -130,7 +130,7 @@ defmodule OpenapiPetstore.Api.User do
   {:ok, %OpenapiPetstore.Model.User{}} on success
   {:error, info} on failure
   """
-  @spec get_user_by_name(Tesla.Env.client, String.t, keyword()) :: {:ok, OpenapiPetstore.Model.User.t} | {:error, Tesla.Env.t}
+  @spec get_user_by_name(Tesla.Env.client, String.t, keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.User.t} | {:error, Tesla.Env.t}
   def get_user_by_name(connection, username, _opts \\ []) do
     %{}
     |> method(:get)
@@ -158,7 +158,7 @@ defmodule OpenapiPetstore.Api.User do
   {:ok, %OpenapiPetstore.Model.String.t{}} on success
   {:error, info} on failure
   """
-  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, String.t} | {:error, Tesla.Env.t}
+  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String.t} | {:error, Tesla.Env.t}
   def login_user(connection, username, password, _opts \\ []) do
     %{}
     |> method(:get)


### PR DESCRIPTION
This PR fixes the wrong typespec for mutiple return types.

It does first building and generating a list for every return type defined. Those are saved in a HashList to ensures that every defintion will only be present once.
After that, the list will be added to the existing StringBuffer and adding the `{:error, Tesla.Env.t}` at the end of the typespec.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.